### PR TITLE
Return whole data

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,15 @@ match_id = mindmatch.create_match(
 )
 #=> '6906ec3d-024d-43c6-a1cf-9b102eec4fb1'
 mindmatch.query_match(id: match_id)
-#=> {"id"=>"6906ec3d-024d-43c6-a1cf-9b102eec4fb1", "status"=>"fulfilled", "results"=>[{"score"=>0.1436655436}]}
+#=> {"id"=>"53b03dc2-07dd-40a2-91fe-7bff24c86574",
+     "status"=>"fulfilled",
+     "data"=>
+     {"results"=>
+       [{"score"=>0.1436655436,
+         "personId"=>"7dedffb3-c41e-4046-aa3d-73979d7ec1c2",
+         "positionId"=>"6214ab8d26e3f79571d922ca269d5743"}],
+      "people"=>[{"id"=>"7dedffb3-c41e-4046-aa3d-73979d7ec1c2", "refId"=>"2"}],
+      "positions"=>[{"id"=>"6214ab8d26e3f79571d922ca269d5743", "refId"=>"324"}]}}
 ```
 
 

--- a/lib/mind_match/client.rb
+++ b/lib/mind_match/client.rb
@@ -58,9 +58,7 @@ module MindMatch
       end
       handle_error(raw_response)
       response = JSON.parse(raw_response.body)
-      match = response.dig('data', 'match')
-      match = match['data'] if match.has_key?('data') # FIX: remove data namespece in mindmatch api
-      match
+      response.dig('data', 'match')
     end
 
     private

--- a/lib/mind_match/client.rb
+++ b/lib/mind_match/client.rb
@@ -58,7 +58,8 @@ module MindMatch
       end
       handle_error(raw_response)
       response = JSON.parse(raw_response.body)
-      response.dig('data', 'match')
+      response = response['data'] if response.has_key?('data')
+      response['match']
     end
 
     private

--- a/spec/mind_match_spec.rb
+++ b/spec/mind_match_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe MindMatch do
         ]
       }]
     }
+
     let(:position) { {
         "id" => 324,
         "name" => "Elixir Frontend Developer",
@@ -36,13 +37,42 @@ RSpec.describe MindMatch do
 
     it 'returns an id for a list of talents & position' do
       VCR.use_cassette("create_match") do
-        expect(mindmatch.create_match(talents: talents, position: position)).to eql('7e117fde-eb2c-423b-818e-86447b7049f3')
+        expect(mindmatch.create_match(talents: talents, position: position)).to eql('1d7964c9-7219-4d77-aee3-ece7919f9af5')
       end
     end
 
-    it 'returns a score for a match id' do
+    let(:match) { mindmatch.query_match(id: '6ecc0537-63ea-4a39-9d4c-e2c2b054b70d') }
+
+    it 'returns the status for a match id' do
       VCR.use_cassette("query_match") do
-        expect(mindmatch.query_match(id: '6906ec3d-024d-43c6-a1cf-9b102eec4fb1')['results'].first['score']).to eql(0.1436655436)
+        expect(match["id"]).to eql('53b03dc2-07dd-40a2-91fe-7bff24c86574')
+        expect(match["status"]).to eql('fulfilled')
+      end
+    end
+
+    let(:match_result) { match.dig("data", "results")[0] }
+
+    it 'returns the score and the ids for a match id' do
+      VCR.use_cassette("query_match") do
+        expect(match_result["score"]).to eql(0.1436655436)
+        expect(match_result["personId"]).to eql('7dedffb3-c41e-4046-aa3d-73979d7ec1c2')
+        expect(match_result["positionId"]).to eql('6214ab8d26e3f79571d922ca269d5743')
+      end
+    end
+
+    let(:match_people) { match.dig("data", "people")[0] }
+
+    it 'returns the persoun ids object for a match id' do
+      VCR.use_cassette("query_match") do
+        expect(match_people["id"]) .to eql('7dedffb3-c41e-4046-aa3d-73979d7ec1c2')
+      end
+    end
+
+    let(:match_positions) { match.dig("data", "positions")[0] }
+
+    it 'returns the position ids object for a match id' do
+      VCR.use_cassette("query_match") do
+        expect(match_positions["id"]) .to eql('6214ab8d26e3f79571d922ca269d5743')
       end
     end
 
@@ -62,7 +92,7 @@ RSpec.describe MindMatch do
 
       it 'returns an id for a list of talents & position' do
         VCR.use_cassette("create_match_with_company_data") do
-          expect(mindmatch.create_match(talents: talents, position: position)).to eql('f6645b3c-c504-4755-a9fa-1f74354a51f5')
+          expect(mindmatch.create_match(talents: talents, position: position)).to eql('5ab36ee2-2121-49db-bf3d-8623fa4e0a09')
         end
       end
     end

--- a/spec/vcr_cassettes/create_match.yml
+++ b/spec/vcr_cassettes/create_match.yml
@@ -17,7 +17,7 @@ http_interactions:
         {\n            id\n          }\n        }\n"}'
     headers:
       Authorization:
-      - Bearer XvtLRvsxNr4tOpmVpVFNWkJrxyc24hkjZA
+      - Bearer yourtokencomeshere
       Accept:
       - application/json
       Content-Type:
@@ -54,11 +54,11 @@ http_interactions:
       Content-Length:
       - '91'
       Etag:
-      - W/"5b-0D6vFpSK+rT3CFClAISzK4tQY/o"
+      - W/"5b-UgFewtKHjy6s1/Z5/UEXBP92MQU"
       Vary:
       - Accept-Encoding
       Date:
-      - Mon, 25 Sep 2017 15:16:08 GMT
+      - Fri, 29 Sep 2017 10:03:31 GMT
       Via:
       - 1.1 vegur
     body:
@@ -67,10 +67,10 @@ http_interactions:
         {
           "data": {
             "match": {
-              "id": "7e117fde-eb2c-423b-818e-86447b7049f3"
+              "id": "1d7964c9-7219-4d77-aee3-ece7919f9af5"
             }
           }
         }
-    http_version: 
-  recorded_at: Mon, 25 Sep 2017 15:16:08 GMT
+    http_version:
+  recorded_at: Fri, 29 Sep 2017 10:03:31 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/create_match_invalid_data.yml
+++ b/spec/vcr_cassettes/create_match_invalid_data.yml
@@ -10,12 +10,12 @@ http_interactions:
         location: [\"location\"], url: \"http://example.com\", profileUrls: [\"https://github.com/honeypotio\",
         \"https://linkedin.com/company/honeypot\"], positions: [{ refId: \"324\",
         name: \"\", description: \"\" }] }],\n                people: [{ refId: \"2\",
-        name: \"Hugo Duksis\", email: \"\", profileUrls: , resumeUrl: \"\", skills:
+        name: \"Hugo Duksis\", email: \"\", profileUrls: [], resumeUrl: \"\", skills:
         [\"Javascript\", \"ruby\", \"elixir\", \"git\"] }]\n              }\n            }\n          )
         {\n            id\n          }\n        }\n"}'
     headers:
       Authorization:
-      - Bearer yourtokengoeshere
+      - Bearer yourtokencomeshere
       Accept:
       - application/json
       Content-Type:
@@ -26,8 +26,8 @@ http_interactions:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
-      code: 400
-      message: Bad Request
+      code: 200
+      message: OK
     headers:
       Server:
       - Cowboy
@@ -50,31 +50,25 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '770'
+      - '91'
       Etag:
-      - W/"302-0lyxQgoXTxUFVRSNt8jveCN67Fo"
+      - W/"5b-Sx/ln0Q54EC0L2HzWrQ2saUXaMU"
       Vary:
       - Accept-Encoding
       Date:
-      - Wed, 27 Sep 2017 16:51:01 GMT
+      - Fri, 29 Sep 2017 10:03:32 GMT
       Via:
       - 1.1 vegur
     body:
       encoding: UTF-8
       string: |-
         {
-          "errors": [
-            {
-              "message": "Syntax Error GraphQL request (6:96) Expected Name, found :\n\n5:                 companies: [{ name: \"company\", location: [\"location\"], url: \"http://example.com\", profileUrls: [\"https://github.com/honeypotio\", \"https://linkedin.com/company/honeypot\"], positions: [{ refId: \"324\", name: \"\", description: \"\" }] }],\n6:                 people: [{ refId: \"2\", name: \"Hugo Duksis\", email: \"\", profileUrls: , resumeUrl: \"\", skills: [\"Javascript\", \"ruby\", \"elixir\", \"git\"] }]\n                                                                                                  ^\n7:               }\n",
-              "locations": [
-                {
-                  "line": 6,
-                  "column": 96
-                }
-              ]
+          "data": {
+            "match": {
+              "id": "5e793080-4758-4ace-8d9c-02b082fd6615"
             }
-          ]
+          }
         }
     http_version:
-  recorded_at: Wed, 27 Sep 2017 16:51:01 GMT
+  recorded_at: Fri, 29 Sep 2017 10:03:32 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/create_match_with_company_data.yml
+++ b/spec/vcr_cassettes/create_match_with_company_data.yml
@@ -54,11 +54,11 @@ http_interactions:
       Content-Length:
       - '91'
       Etag:
-      - W/"5b-gOoy7Jtrhu4yV+JtF0maz0Y0D5M"
+      - W/"5b-LTjowPPYS+aWawSgfABUdipM+IM"
       Vary:
       - Accept-Encoding
       Date:
-      - Mon, 25 Sep 2017 15:10:03 GMT
+      - Fri, 29 Sep 2017 10:03:32 GMT
       Via:
       - 1.1 vegur
     body:
@@ -67,10 +67,10 @@ http_interactions:
         {
           "data": {
             "match": {
-              "id": "f6645b3c-c504-4755-a9fa-1f74354a51f5"
+              "id": "5ab36ee2-2121-49db-bf3d-8623fa4e0a09"
             }
           }
         }
     http_version:
-  recorded_at: Mon, 25 Sep 2017 15:10:03 GMT
+  recorded_at: Fri, 29 Sep 2017 10:03:32 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/query_match.yml
+++ b/spec/vcr_cassettes/query_match.yml
@@ -5,14 +5,14 @@ http_interactions:
     uri: https://staging-api.mindmatch.ai/graphql
     body:
       encoding: UTF-8
-      string: '{"query":"        query getMatch {\n          match: getMatch(id: \"6906ec3d-024d-43c6-a1cf-9b102eec4fb1\")
+      string: '{"query":"        query getMatch {\n          match: getMatch(id: \"6ecc0537-63ea-4a39-9d4c-e2c2b054b70d\")
         {\n            id\n            status\n            data {\n              results
         {\n                score\n                personId\n                positionId\n              }\n              people
         {\n                id\n                refId\n              }\n              positions
         {\n                id\n                refId\n              }\n            }\n          }\n        }\n"}'
     headers:
       Authorization:
-      - Bearer XvtLRvsxNr4tOpmVpVFNWkJrxyc24hkjZA
+      - Bearer yourtokencomeshere
       Accept:
       - application/json
       Content-Type:
@@ -49,11 +49,11 @@ http_interactions:
       Content-Length:
       - '637'
       Etag:
-      - W/"27d-SCfDV++tLf+dGbiQ19Hf+MfMdOc"
+      - W/"27d-CxmOZD0ZI8lGQH3H/4cxKiLxBZc"
       Vary:
       - Accept-Encoding
       Date:
-      - Mon, 25 Sep 2017 14:36:37 GMT
+      - Fri, 29 Sep 2017 10:03:32 GMT
       Via:
       - 1.1 vegur
     body:
@@ -62,7 +62,7 @@ http_interactions:
         {
           "data": {
             "match": {
-              "id": "6906ec3d-024d-43c6-a1cf-9b102eec4fb1",
+              "id": "53b03dc2-07dd-40a2-91fe-7bff24c86574",
               "status": "fulfilled",
               "data": {
                 "results": [
@@ -88,6 +88,6 @@ http_interactions:
             }
           }
         }
-    http_version: 
-  recorded_at: Mon, 25 Sep 2017 14:36:37 GMT
+    http_version:
+  recorded_at: Fri, 29 Sep 2017 10:03:32 GMT
 recorded_with: VCR 3.0.3


### PR DESCRIPTION
We need to return as more as data as possible when querying MindMatch, which includes overall status, result's `position` and `personId` and so on.